### PR TITLE
Make rofi prompt explicit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,8 @@ use common::query_rofi;
 use i3ipc::I3Connection;
 use structopt::StructOpt;
 
-fn rofi_get_group_name(group_name: Option<String>, group_names: &[&str]) -> Option<String> {
-    group_name.or_else(|| query_rofi("Select group", Some(group_names)))
+fn rofi_get_group_name(msg: &str, group_name: Option<String>, group_names: &[&str]) -> Option<String> {
+    group_name.or_else(|| query_rofi(msg, Some(group_names)))
 }
 
 fn rofi_get_local_number(local_number: Option<usize>) -> Option<usize> {
@@ -42,7 +42,7 @@ fn main() {
             }
         }
         Subcommands::FocusGroup { group_name } => {
-            if let Some(group_name) = rofi_get_group_name(group_name, &group_names) {
+            if let Some(group_name) = rofi_get_group_name("Focus group", group_name, &group_names) {
                 controller.focus_group(&group_name);
             }
         }
@@ -52,7 +52,7 @@ fn main() {
             }
         }
         Subcommands::MoveContainerToGroup { group_name } => {
-            if let Some(group_name) = rofi_get_group_name(group_name, &group_names) {
+            if let Some(group_name) = rofi_get_group_name("Move to group", group_name, &group_names) {
                 controller.move_container_to_group(&group_name);
             }
         }


### PR DESCRIPTION
As a new user, I find it hard to know what will be done with a generic
"Select group" prompt. I almost never know whether I will focus another
group or move current windows to another group.